### PR TITLE
Tree page bugs

### DIFF
--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -26,17 +26,15 @@ def eval_options(options):
 
 class Tree(View):
     tree_index = param.Integer(
-        default=0, allow_None= True, doc="Get tree by zero-based index"
+        default=0, allow_None=True, doc="Get tree by zero-based index"
     )
-    position = param.Integer(
-        default=None, doc="Get tree at genome position (bp)"
-    )
+    position = param.Integer(default=None, doc="Get tree at genome position (bp)")
 
     warning_pane = pn.pane.Alert(
-            "The input for position or tree index is out of bounds.", 
-            alert_type="warning", 
-            visible = False
-        )
+        "The input for position or tree index is out of bounds.",
+        alert_type="warning",
+        visible=False,
+    )
 
     width = param.Integer(default=750, doc="Width of the tree plot")
     height = param.Integer(default=520, doc="Height of the tree plot")
@@ -47,9 +45,7 @@ class Tree(View):
             "Must be a valid dictionary string."
         ),
     )
-    next = param.Action(
-        lambda x: x.next_tree(), doc="Next tree", label="Next tree"
-    )
+    next = param.Action(lambda x: x.next_tree(), doc="Next tree", label="Next tree")
     prev = param.Action(
         lambda x: x.prev_tree(), doc="Previous tree", label="Previous tree"
     )
@@ -58,11 +54,15 @@ class Tree(View):
 
     def next_tree(self):
         self.position = None
-        self.tree_index += 1  # pyright: ignore[reportOperatorIssue]
+        self.tree_index = min(
+            self.datastore.tsm.ts.num_trees - 1, int(self.tree_index) + 1
+        )  # pyright: ignore[reportOperatorIssue]
 
     def prev_tree(self):
         self.position = None
-        self.tree_index = max(0, self.tree_index - 1)  # pyright: ignore[reportOperatorIssue]
+        self.tree_index = max(
+            0, int(self.tree_index) - 1
+        )  # pyright: ignore[reportOperatorIssue]
 
     @property
     def default_css(self):
@@ -79,16 +79,23 @@ class Tree(View):
         css_string = " ".join(styles)
         return css_string
 
-    @param.depends('position','tree_index', watch=True)
+    @param.depends("position", "tree_index", watch=True)
     def check_inputs(self):
-        if self.position is not None and (int(self.position) < 0 or int(self.position) > self.datastore.tsm.ts.sequence_length):
-            self.warning_pane.visible=True
+        if self.position is not None and (
+            int(self.position) < 0
+            or int(self.position) > self.datastore.tsm.ts.sequence_length
+        ):
+            self.warning_pane.visible = True
             raise ValueError
-        if self.tree_index is not None and int(self.tree_index) < 0 or int(self.tree_index) > self.datastore.tsm.ts.num_trees:
-            self.warning_pane.visible=True
+        if (
+            self.tree_index is not None
+            and int(self.tree_index) < 0
+            or int(self.tree_index) > self.datastore.tsm.ts.num_trees
+        ):
+            self.warning_pane.visible = True
             raise ValueError
         else:
-            self.warning_pane.visible=False
+            self.warning_pane.visible = False
 
     @param.depends(
         "width", "height", "position", "options", "symbol_size", "tree_index"
@@ -135,7 +142,7 @@ class Tree(View):
                 active_header_background=config.SIDEBAR_BACKGROUND,
                 styles=config.VCARD_STYLE,
             ),
-            self.warning_pane
+            self.warning_pane,
         )
 
 

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -147,7 +147,7 @@ class Tree(View):
             ),
             self.warning_pane,
         )
-
+ 
 
 class TreesPage(View):
     key = "trees"

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -162,7 +162,7 @@ class Tree(View):
         )
         return sidebar_content
 
-    @param.depends("searchBy.value", watch=True)
+    @param.depends("search_by.value", watch=True)
     def sidebar(self):
         return self.update_sidebar()
 

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -24,6 +24,10 @@ def eval_options(options):
 
 
 class Tree(View):
+    searchBy = pn.widgets.ToggleGroup(
+        name="searchBy", options=["Position", "Tree Index"], behavior="radio"
+    )
+
     tree_index = param.Integer(
         default=0, allow_None=True, doc="Get tree by zero-based index"
     )
@@ -130,23 +134,35 @@ class Tree(View):
             ),
         )
 
-    def sidebar(self):
-        return pn.Column(
+    def update_sidebar(self):
+        """Dynamically update the sidebar based on searchBy value."""
+        print(self.searchBy.value)
+        if self.searchBy.value == "Tree Index":
+            self.position = None
+            fields = [self.param.tree_index]
+        else:
+            fields = [self.param.position]
+
+        sidebar_content = pn.Column(
             pn.Card(
-                self.param.position,
-                self.param.tree_index,
+                self.searchBy,
+                *fields,
                 self.param.width,
                 self.param.height,
                 self.param.options,
                 self.param.symbol_size,
-                collapsed=True,
+                collapsed=False,
                 title="Tree plotting options",
                 header_background=config.SIDEBAR_BACKGROUND,
                 active_header_background=config.SIDEBAR_BACKGROUND,
                 styles=config.VCARD_STYLE,
-            ),
-            self.warning_pane,
+            )
         )
+        return sidebar_content
+
+    @param.depends("searchBy.value", watch=True)
+    def sidebar(self):
+        return self.update_sidebar()
 
 
 class TreesPage(View):

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -29,7 +29,7 @@ class Tree(View):
         default=0, bounds=(0, None), doc="Get tree by zero-based index"
     )
     position = param.Integer(
-        default=None, bounds=(1, None), doc="Get tree at genome position (bp)"
+        default=None, bounds=(0, None), doc="Get tree at genome position (bp)"
     )
     width = param.Integer(default=750, doc="Width of the tree plot")
     height = param.Integer(default=520, doc="Height of the tree plot")
@@ -82,8 +82,8 @@ class Tree(View):
             self.tree_index = tree.index
         else:
             tree = self.datastore.tsm.ts.at_index(self.tree_index)
-        position1 = int(tree.get_interval()[0]) 
-        position2 = int(tree.get_interval()[1])
+        position1 = int(tree.get_interval()[0])
+        position2 = int(tree.get_interval()[1]) - 1
         return pn.Column(
             pn.pane.Markdown(
                 f"## Tree index {self.tree_index} (position {position1} - {position2})"

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -60,11 +60,13 @@ class Tree(View):
         self.position = None
         self.tree_index = min(
             self.datastore.tsm.ts.num_trees - 1, int(self.tree_index) + 1
-        )  # pyright: ignore[reportOperatorIssue]
+        )
+        # pyright: ignore[reportOperatorIssue]
 
     def prev_tree(self):
         self.position = None
-        self.tree_index = max(0, int(self.tree_index) - 1)  # pyright: ignore[reportOperatorIssue]
+        self.tree_index = max(0, int(self.tree_index) - 1)
+        # pyright: ignore[reportOperatorIssue]
 
     @property
     def default_css(self):

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -148,7 +148,7 @@ class Tree(View):
             self.warning_pane,
         )
  
-
+ 
 class TreesPage(View):
     key = "trees"
     title = "Trees"

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -8,7 +8,6 @@ TODO:
 import ast
 
 import holoviews as hv
-import numpy as np
 import panel as pn
 import param
 
@@ -111,11 +110,11 @@ class Tree(View):
             self.tree_index = tree.index
         else:
             tree = self.datastore.tsm.ts.at_index(self.tree_index)
-        position1 = int(tree.get_interval()[0])
-        position2 = int(tree.get_interval()[1]) - 1
+        pos1 = int(tree.get_interval()[0])
+        pos2 = int(tree.get_interval()[1]) - 1
         return pn.Column(
             pn.pane.Markdown(
-                f"## Tree index {self.tree_index} (position {position1} - {position2})"
+                f"## Tree index {self.tree_index} (position {pos1} - {pos2})"
             ),
             pn.pane.HTML(
                 tree.draw_svg(

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -24,7 +24,7 @@ def eval_options(options):
 
 
 class Tree(View):
-    searchBy = pn.widgets.ToggleGroup(
+    search_by = pn.widgets.ToggleGroup(
         name="Search By",
         options=["Position", "Tree Index"],
         behavior="radio",
@@ -139,7 +139,7 @@ class Tree(View):
 
     def update_sidebar(self):
         """Dynamically update the sidebar based on searchBy value."""
-        if self.searchBy.value == "Tree Index":
+        if self.search_by.value == "Tree Index":
             self.position = None
             fields = [self.param.tree_index]
         else:
@@ -147,7 +147,7 @@ class Tree(View):
 
         sidebar_content = pn.Column(
             pn.Card(
-                self.searchBy,
+                self.search_by,
                 *fields,
                 self.param.width,
                 self.param.height,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -17,7 +17,6 @@ from .core import View
 
 hv.extension("bokeh")
 
-
 def eval_options(options):
     """Evaluate options parameter."""
     return ast.literal_eval(options)
@@ -25,7 +24,7 @@ def eval_options(options):
 
 class Tree(View):
     searchBy = pn.widgets.ToggleGroup(
-        name="searchBy", options=["Position", "Tree Index"], behavior="radio"
+        name="Search By", options=["Position", "Tree Index"], behavior="radio", button_type="primary"
     )
 
     tree_index = param.Integer(
@@ -136,7 +135,6 @@ class Tree(View):
 
     def update_sidebar(self):
         """Dynamically update the sidebar based on searchBy value."""
-        print(self.searchBy.value)
         if self.searchBy.value == "Tree Index":
             self.position = None
             fields = [self.param.tree_index]

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -26,14 +26,14 @@ def eval_options(options):
 
 class Tree(View):
     tree_index = param.Integer(
-        default=0, allow_None= True, bounds=(0, None), doc="Get tree by zero-based index"
+        default=0, allow_None= True, doc="Get tree by zero-based index"
     )
     position = param.Integer(
         default=None, doc="Get tree at genome position (bp)"
     )
 
     warning_pane = pn.pane.Alert(
-            "The position entered is out of bounds.", 
+            "The input for position or tree index is out of bounds.", 
             alert_type="warning", 
             visible = False
         )
@@ -79,13 +79,12 @@ class Tree(View):
         css_string = " ".join(styles)
         return css_string
 
-    @param.depends('position', watch=True)
-    def check_position(self):
-        if self.position is not None and int(self.position) < 0:
+    @param.depends('position','tree_index', watch=True)
+    def check_inputs(self):
+        if self.position is not None and (int(self.position) < 0 or int(self.position) > self.datastore.tsm.ts.sequence_length):
             self.warning_pane.visible=True
             raise ValueError
-        max_position = self.datastore.tsm.ts.sequence_length
-        if self.position is not None and int(self.position) > max_position:
+        if self.tree_index is not None and int(self.tree_index) < 0 or int(self.tree_index) > self.datastore.tsm.ts.num_trees:
             self.warning_pane.visible=True
             raise ValueError
         else:

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -31,9 +31,7 @@ class Tree(View):
         button_type="primary",
     )
 
-    tree_index = param.Integer(
-        default=0, allow_None=True, doc="Get tree by zero-based index"
-    )
+    tree_index = param.Integer(default=0, doc="Get tree by zero-based index")
     position = param.Integer(
         default=None, doc="Get tree at genome position (bp)"
     )

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -28,7 +28,9 @@ class Tree(View):
     tree_index = param.Integer(
         default=0, allow_None=True, doc="Get tree by zero-based index"
     )
-    position = param.Integer(default=None, doc="Get tree at genome position (bp)")
+    position = param.Integer(
+        default=None, doc="Get tree at genome position (bp)"
+    )
 
     warning_pane = pn.pane.Alert(
         "The input for position or tree index is out of bounds.",
@@ -45,7 +47,9 @@ class Tree(View):
             "Must be a valid dictionary string."
         ),
     )
-    next = param.Action(lambda x: x.next_tree(), doc="Next tree", label="Next tree")
+    next = param.Action(
+        lambda x: x.next_tree(), doc="Next tree", label="Next tree"
+    )
     prev = param.Action(
         lambda x: x.prev_tree(), doc="Previous tree", label="Previous tree"
     )
@@ -60,9 +64,7 @@ class Tree(View):
 
     def prev_tree(self):
         self.position = None
-        self.tree_index = max(
-            0, int(self.tree_index) - 1
-        )  # pyright: ignore[reportOperatorIssue]
+        self.tree_index = max(0, int(self.tree_index) - 1)  # pyright: ignore[reportOperatorIssue]
 
     @property
     def default_css(self):

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -17,6 +17,7 @@ from .core import View
 
 hv.extension("bokeh")
 
+
 def eval_options(options):
     """Evaluate options parameter."""
     return ast.literal_eval(options)
@@ -24,7 +25,10 @@ def eval_options(options):
 
 class Tree(View):
     searchBy = pn.widgets.ToggleGroup(
-        name="Search By", options=["Position", "Tree Index"], behavior="radio", button_type="primary"
+        name="Search By",
+        options=["Position", "Tree Index"],
+        behavior="radio",
+        button_type="primary",
     )
 
     tree_index = param.Integer(

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -31,8 +31,8 @@ class Tree(View):
     position = param.Integer(
         default=None, bounds=(1, None), doc="Get tree at genome position (bp)"
     )
-    width = param.Integer(default=500, doc="Width of the tree plot")
-    height = param.Integer(default=500, doc="Height of the tree plot")
+    width = param.Integer(default=750, doc="Width of the tree plot")
+    height = param.Integer(default=520, doc="Height of the tree plot")
     options = param.String(
         default="{'y_axis': 'time', 'node_labels': {}}",
         doc=(

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -80,13 +80,13 @@ class Tree(View):
         if self.position is not None:
             tree = self.datastore.tsm.ts.at(self.position)
             self.tree_index = tree.index
-            position = self.position
         else:
             tree = self.datastore.tsm.ts.at_index(self.tree_index)
-            position = int(np.mean(tree.get_interval()))
+        position1 = int(tree.get_interval()[0]) 
+        position2 = int(tree.get_interval()[1])
         return pn.Column(
             pn.pane.Markdown(
-                f"## Tree index {self.tree_index} (position {position})"
+                f"## Tree index {self.tree_index} (position {position1} - {position2})"
             ),
             pn.pane.HTML(
                 tree.draw_svg(

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -147,8 +147,8 @@ class Tree(View):
             ),
             self.warning_pane,
         )
- 
- 
+
+
 class TreesPage(View):
     key = "trees"
     title = "Trees"


### PR DESCRIPTION
Fixing various bugs on the tree page

- Fix tree size
- Add warnings invalid inputs for position & tree index
- Replace the displayed tree position by a range (each tree represents the genealogy for a range of the chromosome)
- Fix so that the tree index can't increase over the maximum bound
- Add a toggle for searching a tree by position or index