### PR TITLE
Advanced options on tree page

### DIFF
--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -52,11 +52,15 @@ class Tree(View):
     )
 
     y_axis = pn.widgets.Checkbox(name="Y-axis", value=True)
+    x_axis = pn.widgets.Checkbox(name="X-axis", value=False)
+    sites_mutations = pn.widgets.Checkbox(name="Sites and mutations", value=True)
     node_labels = param.String(
         default="{}",
         doc=(
             """Show custom labels for the nodes (specified by ID).
-            Any nodes not present will not have a label."""
+            Any nodes not present will not have a label.
+            Examle: {1: 'label1', 2: 'label2',...}"""
+
         ),
     )
 
@@ -120,6 +124,8 @@ class Tree(View):
         "symbol_size",
         "tree_index",
         "y_axis.value",
+        "x_axis.value",
+        "sites_mutations.value",
         "node_labels",
     )
     def __panel__(self):
@@ -130,12 +136,18 @@ class Tree(View):
             tree = self.datastore.tsm.ts.at_index(self.tree_index)
         pos1 = int(tree.get_interval()[0])
         pos2 = int(tree.get_interval()[1]) - 1
+        if self.sites_mutations.value == True:
+            omit_sites = False
+        else:
+            omit_sites = True
         try:
             node_labels = eval_options(self.node_labels)
             plot = tree.draw_svg(
                 size=(self.width, self.height),
                 symbol_size=self.symbol_size,
                 y_axis=self.y_axis.value,
+                x_axis = self.x_axis.value,
+                omit_sites = omit_sites,
                 node_labels=node_labels,
                 style=self.default_css,
             )
@@ -195,6 +207,8 @@ class Tree(View):
                 ),
                 pn.pane.HTML("Include"),
                 self.y_axis,
+                self.x_axis,
+                self.sites_mutations,
                 self.param.symbol_size,
                 self.param.node_labels,
                 collapsed=True,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -130,7 +130,7 @@ class Tree(View):
     def handle_advanced(self):
         if type(self.sites_mutations.value) == bool:
             omit_sites = not self.sites_mutations.value
-        else: 
+        else:
             omit_sites = False
         if self.y_ticks.value is True:
             y_ticks = None

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -128,8 +128,11 @@ class Tree(View):
             self.position_index_warning.visible = False
 
     def handle_advanced(self):
-        omit_sites = not self.sites_mutations.value
-        if self.y_ticks.value:
+        if type(self.sites_mutations.value) == bool:
+            omit_sites = not self.sites_mutations.value
+        else: 
+            omit_sites = False
+        if self.y_ticks.value is True:
             y_ticks = None
         else:
             y_ticks = {}

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -65,7 +65,7 @@ class Tree(View):
             Examle: {1: 'label1', 2: 'label2',...}"""
         ),
     )
-    more_options = param.String(
+    additional_options = param.String(
         default="{}",
         doc=(
             """Add more options as specified by the documentation.
@@ -138,7 +138,7 @@ class Tree(View):
             y_ticks = {}
         if self.node_labels == "":
             self.node_labels = "{}"
-        if self.more_options == "":
+        if self.additional_options == "":
             self.node_options = "{}"
         return omit_sites, y_ticks
 
@@ -153,7 +153,7 @@ class Tree(View):
         "x_axis.value",
         "sites_mutations.value",
         "node_labels",
-        "more_options",
+        "additional_options",
     )
     def __panel__(self):
         if self.position is not None:
@@ -166,7 +166,7 @@ class Tree(View):
         try:
             omit_sites, y_ticks = self.handle_advanced()
             node_labels = eval_options(self.node_labels)
-            more_options = eval_options(self.more_options)
+            additional_options = eval_options(self.additional_options)
             plot = tree.draw_svg(
                 size=(self.width, self.height),
                 symbol_size=self.symbol_size,
@@ -176,7 +176,7 @@ class Tree(View):
                 node_labels=node_labels,
                 y_ticks=y_ticks,
                 style=self.default_css,
-                **more_options,
+                **additional_options,
             )
             self.advanced_warning.visible = False
         except (ValueError, SyntaxError, TypeError):
@@ -243,7 +243,7 @@ class Tree(View):
                 self.sites_mutations,
                 self.param.symbol_size,
                 self.param.node_labels,
-                self.param.more_options,
+                self.param.additional_options,
                 collapsed=True,
                 title="Advanced plotting options",
                 header_background=config.SIDEBAR_BACKGROUND,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -159,7 +159,9 @@ class Tree(View):
     def advanced_options(self):
         sidebar_content = pn.Column(
             pn.Card(
-                pn.pane.HTML("<b>See the <a href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>tskit documentation</a> for more information about these plotting options.<b>"),
+                pn.pane.HTML(
+                    "<b>See the <a href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>tskit documentation</a> for more information about these plotting options.<b>"
+                ),
                 pn.pane.HTML("Include"),
                 self.y_axis,
                 self.param.symbol_size,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -228,8 +228,10 @@ class Tree(View):
             pn.Card(
                 pn.pane.HTML(
                     """<b>See the <a 
-                    href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>
-                    tskit documentation</a> for more information about these plotting options.<b>"""
+                    href='https://tskit.dev/tskit/docs/stable/
+                    python-api.html#tskit.TreeSequence.draw_svg'>
+                    tskit documentation</a> for more information
+                    about these plotting options.<b>"""
                 ),
                 pn.pane.HTML("Include"),
                 self.x_axis,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -123,7 +123,6 @@ class Tree(View):
         "node_labels",
     )
     def __panel__(self):
-
         if self.position is not None:
             tree = self.datastore.tsm.ts.at(self.position)
             self.tree_index = tree.index

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -46,7 +46,7 @@ class Tree(View):
         lambda x: x.prev_tree(), doc="Previous tree", label="Previous tree"
     )
 
-    y_axis = pn.widgets.Checkbox(name='Y-axis', value=True)
+    y_axis = pn.widgets.Checkbox(name="Y-axis", value=True)
     symbol_size = param.Number(default=8, bounds=(0, None), doc="Symbol size")
 
     def next_tree(self):
@@ -94,7 +94,14 @@ class Tree(View):
         else:
             self.warning_pane.visible = False
 
-    @param.depends("width", "height", "position", "symbol_size", "tree_index", "y_axis.value")
+    @param.depends(
+        "width",
+        "height",
+        "position",
+        "symbol_size",
+        "tree_index",
+        "y_axis.value",
+    )
     def __panel__(self):
         if self.position is not None:
             tree = self.datastore.tsm.ts.at(self.position)

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -159,6 +159,7 @@ class Tree(View):
     def advanced_options(self):
         sidebar_content = pn.Column(
             pn.Card(
+                pn.pane.HTML("<b>See the <a href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>tskit documentation</a> for more information about these plotting options.<b>"),
                 pn.pane.HTML("Include"),
                 self.y_axis,
                 self.param.symbol_size,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -128,11 +128,8 @@ class Tree(View):
             self.position_index_warning.visible = False
 
     def handle_advanced(self):
-        if self.sites_mutations.value == True:
-            omit_sites = False
-        else:
-            omit_sites = True
-        if self.y_ticks.value == True:
+        omit_sites = not self.sites_mutations.value
+        if self.y_ticks.value:
             y_ticks = None
         else:
             y_ticks = {}
@@ -179,7 +176,7 @@ class Tree(View):
                 **more_options,
             )
             self.advanced_warning.visible = False
-        except (ValueError, SyntaxError, TypeError) as e:
+        except (ValueError, SyntaxError, TypeError):
             plot = tree.draw_svg(
                 size=(self.width, self.height),
                 y_axis=True,
@@ -230,7 +227,9 @@ class Tree(View):
         sidebar_content = pn.Column(
             pn.Card(
                 pn.pane.HTML(
-                    "<b>See the <a href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>tskit documentation</a> for more information about these plotting options.<b>"
+                    """<b>See the <a 
+                    href='https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg'>
+                    tskit documentation</a> for more information about these plotting options.<b>"""
                 ),
                 pn.pane.HTML("Include"),
                 self.x_axis,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -141,7 +141,6 @@ class Tree(View):
         if self.more_options == "":
             self.node_options = "{}"
         return omit_sites, y_ticks
-    
 
     @param.depends(
         "width",

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -128,10 +128,10 @@ class Tree(View):
             self.position_index_warning.visible = False
 
     def handle_advanced(self):
-        if type(self.sites_mutations.value) == bool:
+        if self.sites_mutations.value is True:
             omit_sites = not self.sites_mutations.value
         else:
-            omit_sites = False
+            omit_sites = True
         if self.y_ticks.value is True:
             y_ticks = None
         else:


### PR DESCRIPTION
- Replacing the precious way of setting advanced options (via entering a dictionary) with a more user friendly menu (with separate input fields and checkboxes)
- Adding a [link to the tskit documentation](https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.draw_svg) for users to read up on the advanced options