### PR TITLE
Sample set creation box improved

### DIFF
--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -264,9 +264,9 @@ class SampleSetsTable(Viewer):
     }
 
     create_sample_set_textinput = param.String(
-        doc="New sample set name. Press Enter (⏎) to create.",
+        doc="Enter name of new sample set. Press Enter (⏎) to create.",
         default=None,
-        label="New sample set name",
+        label="Create new sample set",
     )
 
     warning_pane = pn.pane.Alert(

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -24,7 +24,7 @@ def test_component(page, port, ds):
     page.set_viewport_size({"width": 1920, "height": 1080})
 
     page.get_by_role("button", name="Sample Sets").click()
-    expect(page.get_by_text("New sample set name")).to_be_visible()
+    expect(page.get_by_text("Create new sample set")).to_be_visible()
     expect(page.get_by_text("predefined")).to_be_visible()
 
     page.get_by_role("button", name="Individuals").click()


### PR DESCRIPTION
Changed the sample set page "New sample set name" box label  to "Create new sample set", and improved the clarity of the on hover description. 