### PR TITLE
Merging individuals table and sample sets table

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Python: tseda serve",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "tseda",  // Use the module 'tseda' directly
+        "args": [
+          "serve", "tests/data/test.trees.tseda"  // Arguments to the module
+        ],
+        "console": "integratedTerminal",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder}"
+        },
+        "justMyCode": true,
+        "python": "${workspaceFolder}/.venv/bin/python"
+      }
+    ]
+  }
+  

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -486,13 +486,3 @@ class DataStore(Viewer):
         df = pd.concat(dflist)
         df.set_index(["haplotype", "start", "end"], inplace=True)
         return df
-
-
-
-    # Not needed? Never used?
-    def __panel__(self):
-
-        return pn.Row(
-            self.individuals_table,
-            self.sample_sets_table,
-        )

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -114,7 +114,10 @@ class IndividualsTable(Viewer):
             "values": [False, True],
             "valuesLookup": True,
         }
-        self.formatters = {"selected": {"type": "tickCross"}}
+        self.formatters = {
+            "selected": {"type": "tickCross"},
+            "color": {"type": "color"},
+        }
         self.table.set_index(["id"], inplace=True)
         self.data = self.param.table.rx()
         self.sample_select.options = self.sample_set_indices()
@@ -236,6 +239,7 @@ class IndividualsTable(Viewer):
         )
 
     modification_header = pn.pane.Markdown("#### Batch reassign indivuduals:")
+
     def modification_sidebar(self):
         return pn.Card(
             pn.Column(
@@ -427,13 +431,15 @@ class DataStore(Viewer):
             self.sample_sets_table.data.rx.value,
             left_on="sample_set_id",
             right_index=True,  # Use the index from sample_sets_table or individuals? what index is it?
-            suffixes=('_indiv', '_sample')
+            suffixes=("_indiv", "_sample"),
         )
         combined.reset_index(inplace=True)
-        combined['id'] = combined.index
-        combined.rename(columns={'index': 'id'}, inplace=True)  # Rename the 'index' column to 'id'
+        combined["id"] = combined.index
+        combined.rename(
+            columns={"index": "id"}, inplace=True
+        )  # Rename the 'index' column to 'id'
         return combined
-    
+
     def __init__(self, **params):
         super().__init__(**params)
         combined_data = self.combine_tables
@@ -447,12 +453,17 @@ class DataStore(Viewer):
             "longitude",
             "latitude",
         ]
-        self.individuals_table = IndividualsTable(table=combined_data, columns = combined_columns) # combined
-        
+        # rebinding individuals_table so combined table is globally accessable
+        self.individuals_table = IndividualsTable(
+            table=combined_data, columns=combined_columns
+        )
+
     @property
     def color(self):
         """Return colours of selected individuals."""
-        return self.individuals_table.data.rx.value.loc[self.individuals_table.data.rx.value.selected].color # combined
+        return self.individuals_table.data.rx.value.loc[
+            self.individuals_table.data.rx.value.selected
+        ].color
 
     def haplotype_gnn(self, focal_ind, windows=None):
         samples, sample_sets = self.individuals_table.sample_sets()

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -45,26 +45,9 @@ class IndividualsTable(Viewer):
     """Class to hold and view individuals and perform calculations to
     change filters."""
 
-    columns = [
-        "name",
-        "population",
-        "sample_set_id",
-        "selected",
-        "longitude",
-        "latitude",
-    ]
-    editors = {k: None for k in columns}  # noqa
-    editors["sample_set_id"] = {
-        "type": "number",
-        "valueLookup": True,
-    }
-    editors["selected"] = {
-        "type": "list",
-        "values": [False, True],
-        "valuesLookup": True,
-    }
-    formatters = {"selected": {"type": "tickCross"}}
-
+    columns = param.List(default=[], doc="Columns for the table")
+    editors = param.Dict(default={}, doc="Column editors")
+    formatters = param.Dict(default={}, doc="Column formatters")
     table = param.DataFrame()
 
     page_size = param.Selector(
@@ -112,8 +95,31 @@ class IndividualsTable(Viewer):
 
     def __init__(self, **params):
         super().__init__(**params)
+        default_columns = [
+            "name",
+            "population",
+            "sample_set_id",
+            "selected",
+            "longitude",
+            "latitude",
+        ]
+        # print(self.columns)
+        self.columns = self.columns if self.columns else default_columns
+        print(self.columns)
+        self.editors = {k: None for k in self.columns}
+        self.editors["sample_set_id"] = {
+            "type": "number",
+            "valueLookup": True,
+        }
+        self.editors["selected"] = {
+            "type": "list",
+            "values": [False, True],
+            "valuesLookup": True,
+        }
+        self.formatters = {"selected": {"type": "tickCross"}}
         self.table.set_index(["id"], inplace=True)
         self.data = self.param.table.rx()
+        # print(self.data.rx.value)
         self.sample_select.options = self.sample_set_indices()
         self.sample_select.value = self.sample_set_indices()
 
@@ -206,7 +212,8 @@ class IndividualsTable(Viewer):
             else:
                 logger.info("No population defined")
         data = self.data[self.columns]
-
+        print("creating table")
+        print(self.columns)
         table = pn.widgets.Tabulator(
             data,
             pagination="remote",

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -216,16 +216,19 @@ class IndividualsTable(Viewer):
         else:
             self.data_mod_warning.visible = False
             return False
+        
+    def select_sample_sets(self):
+            if isinstance(self.sample_select.value, list):
+                self.data.rx.value["selected"] = False
+                for sample_set_id in self.sample_select.value:
+                    self.data.rx.value.loc[
+                        self.data.rx.value.sample_set_id == sample_set_id,
+                        "selected",
+                    ] = True
 
     @pn.depends("page_size", "sample_select.value", "mod_update_button.value")
     def __panel__(self):
-        if isinstance(self.sample_select.value, list):
-            self.data.rx.value["selected"] = False
-            for sample_set_id in self.sample_select.value:
-                self.data.rx.value.loc[
-                    self.data.rx.value.sample_set_id == sample_set_id,
-                    "selected",
-                ] = True
+        self.select_sample_sets()
         if self.check_data_modification():
             self.table.loc[
                 self.table["population"] == self.population_from,  # pyright: ignore[reportIndexIssue]

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -104,7 +104,6 @@ class IndividualsTable(Viewer):
             "latitude",
         ]
         self.columns = self.columns if self.columns else default_columns
-        print(self.columns)
         self.editors = {k: None for k in self.columns}
         self.editors["sample_set_id"] = {
             "type": "number",
@@ -453,7 +452,6 @@ class DataStore(Viewer):
     @property
     def color(self):
         """Return colours of selected individuals."""
-        print()
         return self.individuals_table.data.rx.value.loc[self.individuals_table.data.rx.value.selected].color # combined
 
     def haplotype_gnn(self, focal_ind, windows=None):

--- a/src/tseda/vpages/individuals.py
+++ b/src/tseda/vpages/individuals.py
@@ -12,25 +12,99 @@ combinations.
 import panel as pn
 import param
 
-from tseda.datastore import IndividualsTable
+from tseda.datastore import IndividualsTable, SampleSetsTable
 
 from .core import View
 from .map import GeoMap
 
 
 class IndividualsPage(View):
+
     key = "individuals"
     title = "Individuals"
-    data = param.ClassSelector(class_=IndividualsTable)
+    individuals_table = param.ClassSelector(class_=IndividualsTable) # for debugging
+    sample_sets_table = param.ClassSelector(class_=SampleSetsTable) # for debugging
     geomap = param.ClassSelector(class_=GeoMap)
+    combined_table = pn.widgets.DataFrame()
+
+    # imported table settings
+    columns = param.List(default=[], doc="Columns for the table")
+    editors = param.Dict(default={}, doc="Column editors")
+    formatters = param.Dict(default={}, doc="Column formatters")
+    page_size = param.Selector(
+        objects=[10, 20, 50, 100, 200, 500],
+        default=20,
+        doc="Number of rows per page to display",
+    )
+    filters = param.Dict()
+
+    # imported sidebar settings  
+    sample_select = pn.widgets.MultiChoice()
+    selected = param.List()
+    mod_update_button = pn.widgets.Button(name="Update")
+
 
     def __init__(self, **params):
         super().__init__(**params)
-        self.data = self.datastore.individuals_table
-        self.geomap = GeoMap(datastore=self.datastore)
+        self.combined_table = self.datastore.combine_tables
 
+        self.individuals_table = self.datastore.individuals_table
+        self.sample_sets_table = self.datastore.sample_sets_table
+        self.geomap = GeoMap(datastore=self.datastore)
+        self.sample_select = self.individuals_table.sample_select
+        self.selected = list(self.individuals_table.data.rx.value.selected)
+
+        self.editors = {k: None for k in self.combined_table.columns}
+        self.editors["sample_set_id"] = {
+            "type": "number",
+            "valueLookup": True,
+        }
+        self.editors["selected"] = {
+            "type": "list",
+            "values": [False, True],
+            "valuesLookup": True,
+        }
+        self.formatters = self.individuals_table.formatters
+        self.filters = self.individuals_table.filters
+        self.page_size = self.individuals_table.page_size
+        self.mod_update_button = self.individuals_table.mod_update_button
+
+    # Triggers same thing twice, needed to stay up to date
+    @pn.depends("selected",
+                "sample_select.value",
+                "page_size",
+                "mod_update_button",
+                "individuals_table.page_size",
+                "individuals_table.sample_select.value", 
+                "individuals_table.mod_update_button.value")
     def __panel__(self):
-        return pn.Column(
+        self.selected = list(self.individuals_table.data.rx.value.selected)
+        self.page_size = self.individuals_table.page_size
+        self.mod_update_button = self.individuals_table.mod_update_button
+
+        self.combined_table = self.datastore.combine_tables
+        pn.bind(self.datastore.combine_tables,
+                self.combined_table,
+                )
+        
+        table = pn.widgets.Tabulator(
+            self.combined_table,
+            pagination="remote",
+            layout="fit_columns",
+            selectable=True,
+            page_size=self.page_size,
+            formatters=self.formatters,
+            editors=self.editors,
+            margin=10,
+            text_align={col: "right" for col in self.combined_table.columns},
+            header_filters=self.filters,
+        )
+        
+        # Hidden row added because panel only updates changes to widgets
+        # depending on individuals_table if individuals_table is rendered
+        hidden_row = pn.Row(self.individuals_table, visible=False) 
+        return pn.Column( 
+            hidden_row,
             self.geomap,
             pn.pane.Markdown(
                 "**Map** - Displays the geographical locations where samples "
@@ -38,7 +112,7 @@ class IndividualsPage(View):
                 "affiliations through colors.",
                 sizing_mode="stretch_width",
             ),
-            self.data,
+            table,
         )
 
     def sidebar(self):
@@ -57,6 +131,6 @@ class IndividualsPage(View):
                 sizing_mode="stretch_width",
             ),
             self.geomap.sidebar,
-            self.data.options_sidebar,
-            self.data.modification_sidebar,
+            self.individuals_table.options_sidebar,
+            self.individuals_table.modification_sidebar,
         )

--- a/src/tseda/vpages/individuals.py
+++ b/src/tseda/vpages/individuals.py
@@ -11,9 +11,8 @@ combinations.
 
 import panel as pn
 import param
-import pandas as pd
 
-from tseda.datastore import IndividualsTable, SampleSetsTable
+from tseda.datastore import IndividualsTable
 
 from .core import View
 from .map import GeoMap
@@ -22,60 +21,20 @@ from .map import GeoMap
 class IndividualsPage(View):
     key = "individuals"
     title = "Individuals"
-    individuals_table = param.ClassSelector(class_=IndividualsTable)
-    sample_sets_table = param.ClassSelector(class_=SampleSetsTable)
-    combined_table = param.ClassSelector(class_=IndividualsTable)
-
+    data = param.ClassSelector(class_=IndividualsTable)
     geomap = param.ClassSelector(class_=GeoMap)
-
-    mod_update_button = pn.widgets.Button(name="Update")
-
-
-    def combine_tables(self):
-        """Combine individuals and sample sets table."""
-        combined = pd.merge(
-            self.individuals_table.data.rx.value,
-            self.sample_sets_table.data.rx.value,
-            left_on="sample_set_id",
-            right_index=True,
-            suffixes=("_indiv", "_sample"),
-        )
-        combined.reset_index(inplace=True)
-        combined["id"] = combined.index
-        combined.rename(
-            columns={"index": "id"}, inplace=True
-        )  
-        return combined
 
     def __init__(self, **params):
         super().__init__(**params)
-        self.individuals_table = self.datastore.individuals_table
-        self.sample_sets_table = self.datastore.sample_sets_table
-        combined_data = self.combine_tables()
-        combined_columns = [
-            "color",
-            "sample_set_id",
-            "name_sample",
-            "population",
-            "name_indiv",
-            "selected",
-            "longitude",
-            "latitude",
-        ]
-        self.combined_table = IndividualsTable(
-            table=combined_data, columns=combined_columns
-        )
-        # print(self.combined_table.data.rx.value)
-
+        self.data = self.datastore.individuals_table
         self.geomap = GeoMap(datastore=self.datastore)
 
-    @pn.depends("mod_update_button.value")
     def __panel__(self):
-        return pn.Column(self.geomap, self.combined_table)
+        return pn.Column(self.geomap, self.data)
 
     def sidebar(self):
         return pn.Column(
             self.geomap.sidebar,
-            self.combined_table.options_sidebar,
-            self.combined_table.modification_sidebar,
+            self.data.options_sidebar,
+            self.data.modification_sidebar,
         )

--- a/src/tseda/vpages/individuals.py
+++ b/src/tseda/vpages/individuals.py
@@ -112,7 +112,8 @@ class IndividualsPage(View):
                 "affiliations through colors.",
                 sizing_mode="stretch_width",
             ),
-            table,
+            table
+
         )
 
     def sidebar(self):

--- a/src/tseda/vpages/individuals.py
+++ b/src/tseda/vpages/individuals.py
@@ -11,8 +11,9 @@ combinations.
 
 import panel as pn
 import param
+import pandas as pd
 
-from tseda.datastore import IndividualsTable
+from tseda.datastore import IndividualsTable, SampleSetsTable
 
 from .core import View
 from .map import GeoMap
@@ -21,20 +22,60 @@ from .map import GeoMap
 class IndividualsPage(View):
     key = "individuals"
     title = "Individuals"
-    data = param.ClassSelector(class_=IndividualsTable)
+    individuals_table = param.ClassSelector(class_=IndividualsTable)
+    sample_sets_table = param.ClassSelector(class_=SampleSetsTable)
+    combined_table = param.ClassSelector(class_=IndividualsTable)
+
     geomap = param.ClassSelector(class_=GeoMap)
+
+    mod_update_button = pn.widgets.Button(name="Update")
+
+
+    def combine_tables(self):
+        """Combine individuals and sample sets table."""
+        combined = pd.merge(
+            self.individuals_table.data.rx.value,
+            self.sample_sets_table.data.rx.value,
+            left_on="sample_set_id",
+            right_index=True,
+            suffixes=("_indiv", "_sample"),
+        )
+        combined.reset_index(inplace=True)
+        combined["id"] = combined.index
+        combined.rename(
+            columns={"index": "id"}, inplace=True
+        )  
+        return combined
 
     def __init__(self, **params):
         super().__init__(**params)
-        self.data = self.datastore.individuals_table
+        self.individuals_table = self.datastore.individuals_table
+        self.sample_sets_table = self.datastore.sample_sets_table
+        combined_data = self.combine_tables()
+        combined_columns = [
+            "color",
+            "sample_set_id",
+            "name_sample",
+            "population",
+            "name_indiv",
+            "selected",
+            "longitude",
+            "latitude",
+        ]
+        self.combined_table = IndividualsTable(
+            table=combined_data, columns=combined_columns
+        )
+        # print(self.combined_table.data.rx.value)
+
         self.geomap = GeoMap(datastore=self.datastore)
 
+    @pn.depends("mod_update_button.value")
     def __panel__(self):
-        return pn.Column(self.geomap, self.data)
+        return pn.Column(self.geomap, self.combined_table)
 
     def sidebar(self):
         return pn.Column(
             self.geomap.sidebar,
-            self.data.options_sidebar,
-            self.data.modification_sidebar,
+            self.combined_table.options_sidebar,
+            self.combined_table.modification_sidebar,
         )

--- a/src/tseda/vpages/map.py
+++ b/src/tseda/vpages/map.py
@@ -41,9 +41,7 @@ class GeoMap(View):
         doc="Select XYZ tiles for map",
     )
     tiles = tiles_options[tiles_selector.default]
-    refresh_button = pn.widgets.Button(name="Refresh map")
 
-    @pn.depends("refresh_button.value")
     def __panel__(self):
         self.tiles = tiles_options[self.tiles_selector]
         df = self.datastore.individuals_table.data.rx.value
@@ -93,7 +91,6 @@ class GeoMap(View):
     def sidebar(self):
         return pn.Card(
             self.param.tiles_selector,
-            self.refresh_button,
             collapsed=False,
             title="Map options",
             header_background=config.SIDEBAR_BACKGROUND,

--- a/src/tseda/vpages/map.py
+++ b/src/tseda/vpages/map.py
@@ -41,7 +41,10 @@ class GeoMap(View):
         doc="Select XYZ tiles for map",
     )
     tiles = tiles_options[tiles_selector.default]
+    # cant remove button witout page breaking
+    refresh_button = pn.widgets.Button(name="Refresh map", visible=False)
 
+    @pn.depends("refresh_button.value")
     def __panel__(self):
         self.tiles = tiles_options[self.tiles_selector]
         df = self.datastore.individuals_table.data.rx.value
@@ -91,6 +94,7 @@ class GeoMap(View):
     def sidebar(self):
         return pn.Card(
             self.param.tiles_selector,
+            self.refresh_button,
             collapsed=False,
             title="Map options",
             header_background=config.SIDEBAR_BACKGROUND,


### PR DESCRIPTION
This PR merges the individuals table and the sample sets table into a single combined table containing the data from both. However, this introduces an issue where the table no longer updates correctly.

The current solution is buggy - it requires two page reloads to apply changes and depends on the original individuals table being included (but hidden) on the page for updates to function. Other than these issues, the table is technically functional.

![image](https://github.com/user-attachments/assets/328e0882-0187-44bf-8e31-225148df985c)
