### PR TITLE
Individuals page: sorting selected individuals first

### DIFF
--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -235,7 +235,10 @@ class IndividualsTable(Viewer):
             page_size=self.page_size,
             formatters=self.formatters,
             editors=self.editors,
-            sorters=[ {'field': 'id', 'dir': 'asc'}, {'field': 'selected', 'dir': 'des'}],
+            sorters=[
+                {"field": "id", "dir": "asc"},
+                {"field": "selected", "dir": "des"},
+            ],
             margin=10,
             text_align={col: "right" for col in self.columns},
             header_filters=self.filters,

--- a/src/tseda/datastore.py
+++ b/src/tseda/datastore.py
@@ -235,6 +235,7 @@ class IndividualsTable(Viewer):
             page_size=self.page_size,
             formatters=self.formatters,
             editors=self.editors,
+            sorters=[ {'field': 'id', 'dir': 'asc'}, {'field': 'selected', 'dir': 'des'}],
             margin=10,
             text_align={col: "right" for col in self.columns},
             header_filters=self.filters,


### PR DESCRIPTION
Changed the default sorting order on the individuals table to always show the selected samples first
