### PR TITLE
iGNN sort sample sets

### DIFF
--- a/src/tseda/vpages/ignn.py
+++ b/src/tseda/vpages/ignn.py
@@ -292,6 +292,15 @@ class VBar(View):
                 ["sample_set_id"] + [self.sorting] + ["sample_id", "id"]  # pyright: ignore[reportOperatorIssue]
             )
             ascending = [True, False, False, False]
+
+            columns = df.columns.tolist()
+            columns.remove(self.sorting)
+            id_index = columns.index('id')
+            columns.insert(id_index + 1, self.sorting)
+            df = df[columns]
+            sorting_index = groups.index(self.sorting)
+            groups[sorting_index], groups[0] = groups[0], groups[sorting_index]
+            color[sorting_index], color[0] = color[0], color[sorting_index]
         else:
             sort_by = ["sample_set_id", "sample_id", "id"]
             ascending = [True, False, False]

--- a/src/tseda/vpages/ignn.py
+++ b/src/tseda/vpages/ignn.py
@@ -295,7 +295,7 @@ class VBar(View):
 
             columns = df.columns.tolist()
             columns.remove(self.sorting)
-            id_index = columns.index('id')
+            id_index = columns.index("id")
             columns.insert(id_index + 1, self.sorting)
             df = df[columns]
             sorting_index = groups.index(self.sorting)


### PR DESCRIPTION
We previously merged a PR that lets the user define the order to sort the individuals in the iGNN plot by selecting population from a dropdown menu. This PR makes sure that the selected population will appear at the bottom of each bar, to make the graph clearer, i.e. solving [this issue](https://github.com/tforest/tseda/issues/15)