### PR TITLE
Tree page features

### DIFF
--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -55,7 +55,8 @@ class Tree(View):
         name="Number of trees",
         options=[1, 2, 3, 4, 5, 6],
         value=1,
-        description="Select the number of trees to display. The first tree will represent your selected chromosome position or tree index.",
+        description="""Select the number of trees to display. The first tree 
+        will represent your selected chromosome position or tree index.""",
     )
 
     y_axis = pn.widgets.Checkbox(name="Include y-axis", value=True)

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -331,7 +331,7 @@ class Tree(View):
             all_trees,
             pn.pane.Markdown(
                 """**Tree plot** - Lorem Ipsum... 
-            Selected samples have are marked with a black outline."""
+            Selected samples are marked with a black outline."""
             ),
             self.slider,
             pn.Row(

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -254,6 +254,9 @@ class Tree(View):
         selected_samples = [
             int(i) for sublist in list(sample_sets.values()) for i in sublist
         ]
+        if len(selected_samples) < 1:
+            self.pack_unselected.value = False
+            self.pack_unselected.disabled = True
         omit_sites, y_ticks = self.handle_advanced()
         try:
             node_labels = eval_options(self.node_labels)

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -138,10 +138,24 @@ class Tree(View):
         sample_sets = self.datastore.sample_sets_table.data.rx.value
         individuals = self.datastore.individuals_table.data.rx.value
         sample2ind = self.datastore.individuals_table.sample2ind
+        selected_sample_sets = self.datastore.individuals_table.sample_sets()
+        selected_samples = [
+            int(i)
+            for sublist in list(selected_sample_sets.values())
+            for i in sublist
+        ]
         for n in self.datastore.individuals_table.samples():
             ssid = individuals.loc[sample2ind[n]].sample_set_id
             ss = sample_sets.loc[ssid]
-            s = f".node.n{n} > .sym " + "{" + f"fill: {ss.color} " + "}"
+            if n in selected_samples:
+                s = (
+                    f".node.n{n} > .sym "
+                    + "{"
+                    + f"fill: {ss.color}; stroke: black; stroke-width: 2px;"
+                    + "}"
+                )
+            else:
+                s = f".node.n{n} > .sym " + "{" + f"fill: {ss.color} " + "}"
             styles.append(s)
         css_string = " ".join(styles)
         return css_string
@@ -315,7 +329,8 @@ class Tree(View):
         all_trees = self.get_all_trees(trees)
         return pn.Column(
             all_trees,
-            pn.pane.Markdown("**Tree plot** - Lorem Ipsum"),
+            pn.pane.Markdown("""**Tree plot** - Lorem Ipsum... 
+                             Selected samples have are marked with a black outline."""),
             self.slider,
             pn.Row(
                 self.param.prev,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -242,6 +242,15 @@ class Tree(View):
             self.sites_mutations.value = False
             self.pack_unselected.value = True
             self.symbol_size = 6
+        else:
+            self.width = 750
+            self.height = 520
+            self.y_axis.value = True
+            self.x_axis.value = False
+            self.y_ticks.value = True
+            self.sites_mutations.value = True
+            self.pack_unselected.value = False
+            self.symbol_size = 8
 
     @param.depends(
         "width",

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -329,8 +329,10 @@ class Tree(View):
         all_trees = self.get_all_trees(trees)
         return pn.Column(
             all_trees,
-            pn.pane.Markdown("""**Tree plot** - Lorem Ipsum... 
-                             Selected samples have are marked with a black outline."""),
+            pn.pane.Markdown(
+                """**Tree plot** - Lorem Ipsum... 
+            Selected samples have are marked with a black outline."""
+            ),
             self.slider,
             pn.Row(
                 self.param.prev,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -271,7 +271,7 @@ class Tree(View):
     def __panel__(self):
         try:
             self.check_inputs()
-        except (ValueError):
+        except ValueError:
             self.position_index_warning.visible = True
             raise ValueError("Inputs for position or tree index are not valid")
 

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -51,6 +51,13 @@ class Tree(View):
         lambda x: x.prev_tree(), doc="Previous tree", label="Previous tree"
     )
 
+    num_trees = pn.widgets.Select(
+        name="Number of trees",
+        options=[1, 2, 3, 4, 5, 6],
+        value=1,
+        description="Select the number of trees to display. The first tree will represent your selected chromosome position or tree index.",
+    )
+
     y_axis = pn.widgets.Checkbox(name="Include y-axis", value=True)
     y_ticks = pn.widgets.Checkbox(name="Include y-ticks", value=True)
     x_axis = pn.widgets.Checkbox(name="Include x-axis", value=False)
@@ -220,6 +227,7 @@ class Tree(View):
         "position",
         "symbol_size",
         "tree_index",
+        "num_trees.value",
         "y_axis.value",
         "y_ticks.value",
         "x_axis.value",
@@ -230,14 +238,12 @@ class Tree(View):
         "slider.value_throttled",
     )
     def __panel__(self):
-        num_trees = 5
-
         sample_sets = self.datastore.individuals_table.sample_sets()
         selected_samples = [
             int(i) for sublist in list(sample_sets.values()) for i in sublist
         ]
         trees = []
-        for i in range(num_trees):
+        for i in range(self.num_trees.value):
             if self.position is not None:
                 tree = self.datastore.tsm.ts.at(self.position)
                 self.tree_index = tree.index
@@ -300,6 +306,7 @@ class Tree(View):
                     tskit documentation</a> for more information
                     about these plotting options.<b>"""
                 ),
+                self.num_trees,
                 pn.Row(pn.pane.HTML("Options", width=30), self.options_doc),
                 self.x_axis,
                 self.y_axis,

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -43,7 +43,9 @@ class Tree(View):
     )
 
     position_index_warning = pn.pane.Alert(
-        "The input for position or tree index is out of bounds for the specified number of trees.",
+        """The input for position or tree index is 
+        out of bounds for the specified number 
+        of trees.""",
         alert_type="warning",
         visible=False,
     )

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -257,6 +257,8 @@ class Tree(View):
         if len(selected_samples) < 1:
             self.pack_unselected.value = False
             self.pack_unselected.disabled = True
+        else:
+            self.pack_unselected.disabled = False
         omit_sites, y_ticks = self.handle_advanced()
         try:
             node_labels = eval_options(self.node_labels)

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -220,6 +220,18 @@ class Tree(View):
             return None
         rows = [pn.Row(*trees[i : i + 2]) for i in range(0, len(trees), 2)]
         return pn.Column(*rows)
+    
+    @param.depends("num_trees.value", watch=True)
+    def multiple_trees(self):
+        if int(self.num_trees.value) > 1:
+            self.width = 470
+            self.height = 470
+            self.y_axis.value = False
+            self.x_axis.value = False
+            self.y_ticks.value = False
+            self.sites_mutations.value = False
+            self.pack_unselected.value = True
+            self.symbol_size =6
 
     @param.depends(
         "width",

--- a/src/tseda/vpages/trees.py
+++ b/src/tseda/vpages/trees.py
@@ -31,9 +31,15 @@ class Tree(View):
         button_type="primary",
     )
 
-    tree_index = param.Integer(default=0, doc="Get tree by zero-based index")
+    tree_index = param.Integer(
+        default=0,
+        doc="""Get tree by zero-based index. If multiple trees are 
+        shown, this is the index of the first tree.""",
+    )
     position = param.Integer(
-        default=None, doc="Get tree at genome position (bp)"
+        default=None,
+        doc="""Get tree at genome position (bp). If multiple trees are 
+        shown, this is the position of the first tree.""",
     )
 
     position_index_warning = pn.pane.Alert(
@@ -256,8 +262,9 @@ class Tree(View):
     def __panel__(self):
         try:
             self.check_inputs()
-        except ValueError:
+        except (ValueError):
             self.position_index_warning.visible = True
+            raise ValueError("Inputs for position or tree index are not valid")
 
         sample_sets = self.datastore.individuals_table.sample_sets()
         selected_samples = [

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -19,4 +19,4 @@ def test_treespage(treespage):
 
 
 def test_tree(tree):
-    assert ".node.n26 > .sym {fill: #e4ae38 " in tree.default_css
+    assert ".node.n26 > .sym {fill: #e4ae38}" in tree.default_css

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -19,4 +19,4 @@ def test_treespage(treespage):
 
 
 def test_tree(tree):
-    assert ".node.n26 > .sym {fill: #e4ae38 }" in tree.default_css
+    assert ".node.n26 > .sym" in tree.default_css

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -19,4 +19,7 @@ def test_treespage(treespage):
 
 
 def test_tree(tree):
-    assert ".node.n26 > .sym {fill: #e4ae38}" in tree.default_css
+    assert (
+        ".node.n26 > .sym {fill: #e4ae38}" in tree.default_css
+        or ".node.n26 > .sym {fill: #e4ae38}; stroke: black; stroke-width: 2px;"
+    )

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -19,4 +19,4 @@ def test_treespage(treespage):
 
 
 def test_tree(tree):
-    assert ".node.n26 > .sym" in tree.default_css
+    assert ".node.n26 > .sym {fill: #e4ae38 " in tree.default_css


### PR DESCRIPTION
**Add the option to pack unselected samples in the trees**
As specified in [tforest#31](https://github.com/tforest/tseda/issues/31).
The tracked samples will be the sample sets selected on the individuals page. The sample selection is not done on the tree page, it is done on the individuals page, just as for all other pages and graphs. I decided not to color the selected samples in any specific color, as all sample sets already have unique colors which can be easily found in the samples table quick view in the sidebar of the trees page. To mark the selected samples, I just gave them a black outline. The  "Pack unselected samples" option in the advanced menu is turned off when there are no selected samples.


**Add option to display multiple trees at once**
As specified in [tforest#26](https://github.com/tforest/tseda/issues/26).
Note that the option for toggling the visibility of single trees has not been added yet, this will be done when fixing issue #60 which concerns adding toggles for the visibility of several graphs in the application. As a default for now, I added a maximum of 6 trees, but this could easily be adjusted. I also changed the default settings of the tree plots so that when there is more than one tree, the width, height and node size is adjusted, and extra options such as axes and labels are excluded from the plot, this can however be adjusted by the user.
