### PR TITLE
Statistics page: bug fix

### DIFF
--- a/src/tseda/vpages/stats.py
+++ b/src/tseda/vpages/stats.py
@@ -10,7 +10,6 @@ TODO:
 
 import ast
 import itertools
-import numpy as np
 
 import holoviews as hv
 import pandas as pd

--- a/src/tseda/vpages/stats.py
+++ b/src/tseda/vpages/stats.py
@@ -10,6 +10,7 @@ TODO:
 
 import ast
 import itertools
+import numpy as np
 
 import holoviews as hv
 import pandas as pd
@@ -240,7 +241,9 @@ class MultiwayStats(View):
             if x in all_sample_sets_sorted and y in all_sample_sets_sorted
         ]
         if comparisons_indexes == []:
-            comparisons_indexes = comparisons
+            return pn.pane.Markdown(
+                "**Select which sample sets to compare to see this plot.**"
+            )
         if self.statistic == "Fst":
             data = tsm.ts.Fst(
                 sample_sets_individuals,


### PR DESCRIPTION
There was a bug on the statistics page which led it to note lode correctly when some changes were made to the sample sets, such as adding new sample sets, selecting/unselecting sample sets and reassigning samples to new sets.

This PR fixes that bug